### PR TITLE
Allow paralell entries to secure world

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,8 @@ optee-objs:=   \
 		generic/tee_kernel_api.o \
 		generic/tee_supp_com.o \
 		generic/tee_mem.o \
-		generic/tee_op.o
+		generic/tee_op.o \
+		generic/tee_mutex_wait.o
 
 ifeq ($(ARCH),arm)
 ccflags-y+=-iquote$(M)/core/armv7

--- a/core/armv7/tee_tz.c
+++ b/core/armv7/tee_tz.c
@@ -50,7 +50,10 @@ static void *tz_outer_cache_mutex;
 
 /* protect concurrent access to the tee-tz: inits, entry */
 static DEFINE_MUTEX(g_mutex_teez);
+
 static DEFINE_MUTEX(e_mutex_teez);
+static DECLARE_COMPLETION(e_comp_teez);
+static int e_num_waiters;
 
 /* device data */
 struct tee_driver tee_tz_data;
@@ -62,12 +65,170 @@ static bool tee_tz_ready;
  * Calling TEE
  *******************************************************************/
 
+static void e_lock_teez(void)
+{
+	mutex_lock(&e_mutex_teez);
+}
+
+static void e_lock_wait_completion_teez(void)
+{
+	/*
+	 * Release the lock until "something happens" and then reacquire it
+	 * again.
+	 *
+	 * This is needed when TEE returns "busy" and we need to try again
+	 * later.
+	 */
+	e_num_waiters++;
+	mutex_unlock(&e_mutex_teez);
+	/*
+	 * Wait at most one second. Secure world is normally never busy
+	 * more than that so we should normally never timeout.
+	 */
+	wait_for_completion_timeout(&e_comp_teez, HZ);
+	mutex_lock(&e_mutex_teez);
+	e_num_waiters--;
+}
+
+static void e_unlock_teez(void)
+{
+	/*
+	 * If at least one thread is waiting for "something to happen" let
+	 * one thread know that "something has happened".
+	 */
+	if (e_num_waiters)
+		complete(&e_comp_teez);
+	mutex_unlock(&e_mutex_teez);
+}
+
+static void handle_rpc_func_cmd_mutex_wait(struct teesmc32_arg *arg32)
+{
+	struct teesmc32_param *params;
+
+	if (arg32->num_params != 2)
+		goto bad;
+
+	params = TEESMC32_GET_PARAMS(arg32);
+
+	if ((params[0].attr & TEESMC_ATTR_TYPE_MASK) !=
+			TEESMC_ATTR_TYPE_VALUE_INPUT)
+		goto bad;
+	if ((params[1].attr & TEESMC_ATTR_TYPE_MASK) !=
+			TEESMC_ATTR_TYPE_VALUE_INPUT)
+		goto bad;
+
+	switch (params[0].u.value.a) {
+	case TEE_MUTEX_WAIT_SLEEP:
+		tee_mutex_wait_sleep(DEV, params[1].u.value.a,
+				     params[1].u.value.b);
+		break;
+	case TEE_MUTEX_WAIT_WAKEUP:
+		tee_mutex_wait_wakeup(DEV, params[1].u.value.a,
+				      params[1].u.value.b);
+		break;
+	case TEE_MUTEX_WAIT_DELETE:
+		tee_mutex_wait_delete(DEV, params[1].u.value.a);
+		break;
+	default:
+		goto bad;
+	}
+
+	arg32->ret = TEEC_SUCCESS;;
+	return;
+bad:
+	arg32->ret = TEEC_ERROR_BAD_PARAMETERS;
+}
+
+static void handle_rpc_func_cmd_to_supplicant(struct teesmc32_arg *arg32)
+{
+	struct teesmc32_param *params;
+	struct tee_rpc_invoke inv;
+	size_t n;
+	uint32_t ret;
+
+	if (arg32->num_params > TEE_RPC_BUFFER_NUMBER) {
+		arg32->ret = TEEC_ERROR_GENERIC;
+		return;
+	}
+
+	params = TEESMC32_GET_PARAMS(arg32);
+
+	memset(&inv, 0, sizeof(inv));
+	inv.cmd = arg32->cmd;
+	/*
+	 * Set a suitable error code in case tee-supplicant
+	 * ignores the request.
+	 */
+	inv.res = TEEC_ERROR_NOT_IMPLEMENTED;
+	inv.nbr_bf = arg32->num_params;
+	for (n = 0; n < arg32->num_params; n++) {
+		inv.cmds[n].buffer = (void *)params[n].u.memref.buf_ptr;
+		inv.cmds[n].size = params[n].u.memref.size;
+		switch (params[n].attr & TEESMC_ATTR_TYPE_MASK) {
+		case TEESMC_ATTR_TYPE_VALUE_INPUT:
+		case TEESMC_ATTR_TYPE_VALUE_OUTPUT:
+		case TEESMC_ATTR_TYPE_VALUE_INOUT:
+			inv.cmds[n].type = TEE_RPC_VALUE;
+			break;
+		case TEESMC_ATTR_TYPE_MEMREF_INPUT:
+		case TEESMC_ATTR_TYPE_MEMREF_OUTPUT:
+		case TEESMC_ATTR_TYPE_MEMREF_INOUT:
+			inv.cmds[n].type = TEE_RPC_BUFFER;
+			break;
+		default:
+			arg32->ret = TEEC_ERROR_GENERIC;
+			return;
+		}
+	}
+
+	ret = tee_supp_cmd(&TZop, TEE_RPC_ICMD_INVOKE,
+				  &inv, sizeof(inv));
+	if (ret == TEEC_RPC_OK)
+		arg32->ret = inv.res;
+
+	for (n = 0; n < arg32->num_params; n++) {
+		switch (params[n].attr & TEESMC_ATTR_TYPE_MASK) {
+		case TEESMC_ATTR_TYPE_VALUE_INPUT:
+		case TEESMC_ATTR_TYPE_VALUE_OUTPUT:
+		case TEESMC_ATTR_TYPE_VALUE_INOUT:
+		case TEESMC_ATTR_TYPE_MEMREF_OUTPUT:
+		case TEESMC_ATTR_TYPE_MEMREF_INOUT:
+			/*
+			 * Allow supplicant to assign a new pointer
+			 * to an out-buffer. Needed when the
+			 * supplicant allocates a new buffer, for
+			 * instance when loading a TA.
+			 */
+			params[n].u.memref.buf_ptr =
+					(uint32_t)inv.cmds[n].buffer;
+			params[n].u.memref.size = inv.cmds[n].size;
+			break;
+		default:
+			break;
+		}
+	}
+}
+
+static void handle_rpc_func_cmd(u32 parg32)
+{
+	struct teesmc32_arg *arg32;
+
+	arg32 = tee_shm_pool_p2v(DEV, TZop.Allocator, parg32);
+
+	if (arg32->cmd == TEE_RPC_MUTEX_WAIT)
+		handle_rpc_func_cmd_mutex_wait(arg32);
+	else
+		handle_rpc_func_cmd_to_supplicant(arg32);
+
+}
+
 static u32 handle_rpc(struct smc_param *param)
 {
 	switch (TEESMC_RETURN_GET_RPC_FUNC(param->a0)) {
 	case TEESMC_RPC_FUNC_ALLOC_ARG:
 		param->a1 = tee_shm_pool_alloc(DEV, TZop.Allocator,
 					param->a1, 4);
+		break;
 	case TEESMC_RPC_FUNC_ALLOC_PAYLOAD:
 		/* Can't support payload shared memory with this interface */
 		param->a2 = 0;
@@ -98,86 +259,14 @@ static u32 handle_rpc(struct smc_param *param)
 	case TEESMC_RPC_FUNC_IRQ:
 		break;
 	case TEESMC_RPC_FUNC_CMD:
-	{
-		struct teesmc32_arg *arg32;
-		struct teesmc32_param *params;
-		struct tee_rpc_invoke inv;
-		size_t n;
-		uint32_t ret;
-
-		arg32 = tee_shm_pool_p2v(DEV, TZop.Allocator, param->a1);
-
-		if (arg32->num_params > TEE_RPC_BUFFER_NUMBER) {
-			arg32->ret = TEEC_ERROR_GENERIC;
-			goto out;
-		}
-
-		params = TEESMC32_GET_PARAMS(arg32);
-
-		memset(&inv, 0, sizeof(inv));
-		inv.cmd = arg32->cmd;
-		/*
-		 * Set a suitable error code in case tee-supplicant
-		 * ignores the request.
-		 */
-		inv.res = TEEC_ERROR_NOT_IMPLEMENTED;
-		inv.nbr_bf = arg32->num_params;
-		for (n = 0; n < arg32->num_params; n++) {
-			inv.cmds[n].buffer = (void *)params[n].u.memref.buf_ptr;
-			inv.cmds[n].size = params[n].u.memref.size;
-			switch (params[n].attr & TEESMC_ATTR_TYPE_MASK) {
-			case TEESMC_ATTR_TYPE_VALUE_INPUT:
-			case TEESMC_ATTR_TYPE_VALUE_OUTPUT:
-			case TEESMC_ATTR_TYPE_VALUE_INOUT:
-				inv.cmds[n].type = TEE_RPC_VALUE;
-				break;
-			case TEESMC_ATTR_TYPE_MEMREF_INPUT:
-			case TEESMC_ATTR_TYPE_MEMREF_OUTPUT:
-			case TEESMC_ATTR_TYPE_MEMREF_INOUT:
-				inv.cmds[n].type = TEE_RPC_BUFFER;
-				break;
-			default:
-				arg32->ret = TEEC_ERROR_GENERIC;
-				goto out;
-			}
-		}
-
-		ret = tee_supp_cmd(&TZop, TEE_RPC_ICMD_INVOKE,
-					  &inv, sizeof(inv));
-		if (ret == TEEC_RPC_OK)
-			arg32->ret = inv.res;
-
-		for (n = 0; n < arg32->num_params; n++) {
-			switch (params[n].attr & TEESMC_ATTR_TYPE_MASK) {
-			case TEESMC_ATTR_TYPE_VALUE_INPUT:
-			case TEESMC_ATTR_TYPE_VALUE_OUTPUT:
-			case TEESMC_ATTR_TYPE_VALUE_INOUT:
-			case TEESMC_ATTR_TYPE_MEMREF_OUTPUT:
-			case TEESMC_ATTR_TYPE_MEMREF_INOUT:
-				/*
-				 * Allow supplicant to assign a new pointer
-				 * to an out-buffer. Needed when the
-				 * supplicant allocates a new buffer, for
-				 * instance when loading a TA.
-				 */
-				params[n].u.memref.buf_ptr =
-						(uint32_t)inv.cmds[n].buffer;
-				params[n].u.memref.size = inv.cmds[n].size;
-				break;
-			default:
-				break;
-			}
-		}
-
+		handle_rpc_func_cmd(param->a1);
 		break;
-	}
 	default:
 		dev_warn(DEV, "Unknown RPC func 0x%x\n",
 			 TEESMC_RETURN_GET_RPC_FUNC(param->a0));
 		break;
 	}
 
-out:
 	if (irqs_disabled())
 		return TEESMC32_FASTCALL_RETURN_FROM_RPC;
 	else
@@ -196,6 +285,7 @@ static void call_tee(uintptr_t parg32, struct teesmc32_arg *arg32)
 		funcid = TEESMC32_CALL_WITH_ARG;
 
 	param.a1 = parg32;
+	e_lock_teez();
 	while (true) {
 		param.a0 = funcid;
 
@@ -203,15 +293,24 @@ static void call_tee(uintptr_t parg32, struct teesmc32_arg *arg32)
 		ret = param.a0;
 
 		if (ret == TEESMC_RETURN_EBUSY) {
-			/* "Can't happen" */
-			BUG_ON(1);
+			/*
+			 * Since secure world returned busy, release the
+			 * lock we had when entering this function and wait
+			 * for "something to happen" (something else to
+			 * exit from secure world and needed resources may
+			 * have become available).
+			 */
+			e_lock_wait_completion_teez();
 		} else if (TEESMC_RETURN_IS_RPC(ret)) {
 			/* Process the RPC. */
+			e_unlock_teez();
 			funcid = handle_rpc(&param);
+			e_lock_teez();
 		} else {
 			break;
 		}
 	}
+	e_unlock_teez();
 
 	switch (ret) {
 	case TEESMC_RETURN_UNKNOWN_FUNCTION:
@@ -361,9 +460,7 @@ static TEEC_Result tee_open_session(struct tee_session *ts,
 
 	set_params(params32 + num_meta, param_type, params);
 
-	mutex_lock(&e_mutex_teez);
 	call_tee(parg32, arg32);
-	mutex_unlock(&e_mutex_teez);
 
 	ts->id = arg32->session;
 	ret_tee = arg32->ret;
@@ -412,9 +509,7 @@ static TEEC_Result tee_invoke_command(struct tee_session *ts,
 
 	set_params(params32, param_type, params);
 
-	mutex_lock(&e_mutex_teez);
 	call_tee(parg32, arg32);
-	mutex_unlock(&e_mutex_teez);
 
 	ret_tee = arg32->ret;
 
@@ -455,9 +550,7 @@ static TEEC_Result tee_cancel_command(struct tee_session *ts,
 	arg32->cmd = TEESMC_CMD_CANCEL;
 	arg32->session = ts->id;
 
-	mutex_lock(&e_mutex_teez);
 	call_tee(parg32, arg32);
-	mutex_unlock(&e_mutex_teez);
 
 	ret_tee = arg32->ret;
 	if (origin)
@@ -494,9 +587,7 @@ static TEEC_Result tee_close_session(struct tee_session *ts,
 	arg32->cmd = TEESMC_CMD_CLOSE_SESSION;
 	arg32->session = ts->id;
 
-	mutex_lock(&e_mutex_teez);
 	call_tee(parg32, arg32);
-	mutex_unlock(&e_mutex_teez);
 
 	ret_tee = arg32->ret;
 	if (origin)
@@ -514,9 +605,7 @@ static TEEC_Result tee_close_session(struct tee_session *ts,
 /* weak outer_tz_mutex in case not supported by kernel */
 bool __weak outer_tz_mutex(unsigned long *p)
 {
-	if (p != NULL)
-		return false;
-	return true;
+	return !p;
 }
 #endif
 
@@ -534,8 +623,6 @@ static int register_l2cc_mutex(bool reg)
 	}
 	if ((reg == false) && (tz_outer_cache_mutex == NULL))
 		return 0;
-
-	mutex_lock(&e_mutex_teez);
 
 	if (reg == false) {
 		vaddr = tz_outer_cache_mutex;
@@ -589,7 +676,6 @@ out:
 		dev_info(DEV, "outer cache shared mutex disabled\n");
 	}
 
-	mutex_unlock(&e_mutex_teez);
 	dev_dbg(DEV, "teetz outer mutex: ret=%d pa=0x%lX va=0x%p %sabled\n",
 		ret, paddr, vaddr, tz_outer_cache_mutex ? "en" : "dis");
 	return ret;
@@ -604,10 +690,8 @@ static int configure_shm(void)
 	if (shm_paddr)
 		return -EINVAL;
 
-	mutex_lock(&e_mutex_teez);
 	param.a0 = TEESMC32_ST_FASTCALL_GET_SHM_CONFIG;
 	tee_smc_call(&param);
-	mutex_unlock(&e_mutex_teez);
 
 	if (param.a0 != TEESMC_RETURN_OK) {
 		dev_err(DEV, "shm service not available: %X", (uint)param.a0);
@@ -729,9 +813,7 @@ static bool teesmc_api_uid_is_st(void)
 {
 	struct smc_param param = { .a0 = TEESMC32_CALLS_UID };
 
-	mutex_lock(&e_mutex_teez);
 	tee_smc_call(&param);
-	mutex_unlock(&e_mutex_teez);
 
 	if (param.a0 == TEESMC_ST_UID_R0 && param.a1 == TEESMC_ST_UID_R1 &&
 	    param.a2 == TEESMC_ST_UID_R2 && (param.a3 == TEESMC_ST_UID32_R3 ||
@@ -745,9 +827,7 @@ static bool teesmc_os_uuid_is_optee(void)
 {
 	struct smc_param param = { .a0 = TEESMC32_CALL_GET_OS_UUID };
 
-	mutex_lock(&e_mutex_teez);
 	tee_smc_call(&param);
-	mutex_unlock(&e_mutex_teez);
 
 	if (param.a0 == TEESMC_OS_OPTEE_UUID_R0 &&
 	    param.a1 == TEESMC_OS_OPTEE_UUID_R1 &&

--- a/generic/tee_driver.h
+++ b/generic/tee_driver.h
@@ -20,6 +20,7 @@
 #include <linux/mutex.h>
 
 #include "tee_supp_com.h"
+#include "tee_mutex_wait.h"
 
 /******************************************************************************/
 
@@ -49,6 +50,7 @@ struct tee_driver {
 	int				count_session;
 	char				*memory_pool;
 	struct	tee_rpc_priv_data	rpc;
+	struct  tee_mutex_wait_private	mutex_wait;
 #if (CFG_TEE_DRV_DEBUGFS == 1)
 	struct	kfifo	cmds;
 #endif

--- a/generic/tee_mem.c
+++ b/generic/tee_mem.c
@@ -546,6 +546,7 @@ void tee_shm_pool_free(struct device *dev, struct shm_pool *pool,
 		unsigned long paddr, uint32_t *size)
 {
 	struct mem_chunk *chunk;
+	struct mem_chunk *tmp;
 
 	if (WARN_ON(!dev || !pool))
 		return;
@@ -562,7 +563,7 @@ void tee_shm_pool_free(struct device *dev, struct shm_pool *pool,
 	if (!is_valid_paddr(pool, paddr))
 		goto out_failed;
 
-	list_for_each_entry(chunk, &pool->mchunks, node) {
+	list_for_each_entry_safe(chunk, tmp, &pool->mchunks, node) {
 		if (chunk->paddr == paddr) {
 			if (size != NULL)
 				*size = chunk->size;

--- a/generic/tee_mutex_wait.c
+++ b/generic/tee_mutex_wait.c
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2014, Linaro Limited
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License Version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+#include <linux/slab.h>
+#include "tee_mutex_wait.h"
+#include "tee-op.h"
+#include "tee_driver.h"
+
+struct tee_mutex_wait {
+	struct list_head link;
+	struct completion comp;
+	struct mutex mu;
+	u32 wait_after;
+	u32 key;
+};
+
+/*
+ * Compares two serial numbers using Serial Number Arithmetic
+ * (https://www.ietf.org/rfc/rfc1982.txt).
+ */
+#define TICK_GT(t1, t2) \
+	(((t1) < (t2) && (t2) - (t1) > 0xFFFFFFFFu) || \
+	((t1) > (t2) && (t1) - (t2) < 0xFFFFFFFFu))
+
+static struct tee_mutex_wait *tee_mutex_wait_get(struct device *dev,
+				struct tee_mutex_wait_private *priv, u32 key)
+{
+	struct tee_mutex_wait *w;
+
+	mutex_lock(&priv->mu);
+
+	list_for_each_entry(w, &priv->db, link)
+		if (w->key == key)
+			goto out;
+
+	w = kmalloc(sizeof(struct tee_mutex_wait), GFP_KERNEL);
+	if (!w) {
+		dev_err(dev, "kmalloc <struct tee_mutex_wait> failed\n");
+		goto out;
+	}
+
+	init_completion(&w->comp);
+	mutex_init(&w->mu);
+	w->wait_after = 0;
+	w->key = key;
+	list_add_tail(&w->link, &priv->db);
+out:
+	mutex_unlock(&priv->mu);
+	return w;
+}
+
+static void tee_mutex_wait_delete_entry(struct tee_mutex_wait *w)
+{
+	list_del(&w->link);
+	mutex_destroy(&w->mu);
+	kfree(w);
+}
+
+void tee_mutex_wait_delete(struct device *dev, u32 key)
+{
+	struct  tee_mutex_wait_private *priv =
+			&tee_get_drvdata(dev)->mutex_wait;
+	struct tee_mutex_wait *w;
+
+	mutex_lock(&priv->mu);
+
+	list_for_each_entry(w, &priv->db, link) {
+		if (w->key == key) {
+			tee_mutex_wait_delete_entry(w);
+			break;
+		}
+	}
+
+	mutex_unlock(&priv->mu);
+}
+
+void tee_mutex_wait_wakeup(struct device *dev, u32 key, u32 wait_after)
+{
+	struct  tee_mutex_wait_private *priv =
+			&tee_get_drvdata(dev)->mutex_wait;
+	struct tee_mutex_wait *w = tee_mutex_wait_get(dev, priv, key);
+
+	if (!w)
+		return;
+
+	mutex_lock(&w->mu);
+	w->wait_after = wait_after;
+	mutex_unlock(&w->mu);
+	complete(&w->comp);
+}
+
+void tee_mutex_wait_sleep(struct device *dev, u32 key, u32 wait_tick)
+{
+	struct  tee_mutex_wait_private *priv =
+			&tee_get_drvdata(dev)->mutex_wait;
+	struct tee_mutex_wait *w = tee_mutex_wait_get(dev, priv, key);
+	u32 wait_after;
+
+	if (!w)
+		return;
+
+	mutex_lock(&w->mu);
+	wait_after = w->wait_after;
+	mutex_unlock(&w->mu);
+
+	if (TICK_GT(wait_tick, wait_after))
+		wait_for_completion_timeout(&w->comp, HZ);
+}
+
+int tee_mutex_wait_init(struct tee_mutex_wait_private *priv)
+{
+	mutex_init(&priv->mu);
+	INIT_LIST_HEAD(&priv->db);
+	return 0;
+}
+
+void tee_mutex_wait_exit(struct tee_mutex_wait_private *priv)
+{
+	/*
+	 * It's the callers responibility to ensure that no one is using
+	 * anything inside priv.
+	 */
+
+	mutex_destroy(&priv->mu);
+	while (!list_empty(&priv->db)) {
+		struct tee_mutex_wait *w =
+				list_first_entry(&priv->db,
+						 struct tee_mutex_wait,
+						 link);
+		tee_mutex_wait_delete_entry(w);
+	}
+}

--- a/generic/tee_mutex_wait.h
+++ b/generic/tee_mutex_wait.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2014, Linaro Limited
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License Version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ */
+#ifndef TEE_MUTEX_WAIT_H
+#define TEE_MUTEX_WAIT_H
+
+#include <linux/mutex.h>
+#include <linux/list.h>
+#include <linux/device.h>
+
+struct tee_mutex_wait_private {
+	struct mutex mu;
+	struct list_head db;
+};
+
+int tee_mutex_wait_init(struct tee_mutex_wait_private *priv);
+void tee_mutex_wait_exit(struct tee_mutex_wait_private *priv);
+void tee_mutex_wait_delete(struct device *dev, u32 key);
+void tee_mutex_wait_wakeup(struct device *dev, u32 key, u32 wait_after);
+void tee_mutex_wait_sleep(struct device *dev, u32 key, u32 wait_tick);
+
+#endif /*TEE_MUTEX_WAIT_H*/

--- a/generic/tee_supp_com.h
+++ b/generic/tee_supp_com.h
@@ -33,6 +33,13 @@
 #define TEE_RPC_VALUE		0x00000002
 #define TEE_RPC_LOAD_TA		0x10000001
 #define TEE_RPC_FREE_TA_WITH_FD	0x10000012
+/* Handled within the driver only */
+#define TEE_RPC_MUTEX_WAIT	0x20000000
+
+/* Parameters for TEE_RPC_WAIT_MUTEX above */
+#define TEE_MUTEX_WAIT_SLEEP	0
+#define TEE_MUTEX_WAIT_WAKEUP	1
+#define TEE_MUTEX_WAIT_DELETE	2
 
 #include <linux/semaphore.h>
 
@@ -77,6 +84,7 @@ struct tee_rpc_priv_data {
 	struct semaphore datafromuser;
 	struct mutex outsync; /* Out sync mutex */
 	struct mutex insync; /* In sync mutex */
+	struct mutex reqsync; /* Request sync mutex */
 };
 
 enum teec_rpc_result {


### PR DESCRIPTION
- Waits for a thread to exit secure world until trying again if
  secure world return "busy"
- Serializes communication with tee-supplicant in case multiple
  threads are trying to communicate with tee-supplicant concurently
- Adds service for secure world to wait until awoken by another
  thread, supporting mutex in secure world
- Bugfix tee_shm_pool_free() to use list_for_each_entry_safe instead
  of list_for_each_entry
