### PR TITLE
Implemented wait in normal world

### DIFF
--- a/core/armv7/tee_tz.c
+++ b/core/armv7/tee_tz.c
@@ -24,6 +24,8 @@
 #include <linux/err.h>
 #include <linux/slab.h>
 #include <linux/moduleparam.h>
+#include <linux/sched.h>
+#include <linux/jiffies.h>
 
 #include <asm/pgtable.h>
 
@@ -139,6 +141,29 @@ bad:
 	arg32->ret = TEEC_ERROR_BAD_PARAMETERS;
 }
 
+static void handle_rpc_func_cmd_wait(struct teesmc32_arg *arg32)
+{
+	struct teesmc32_param *params;
+	u32 msec_to_wait;
+
+	if (arg32->num_params != 1)
+		goto bad;
+
+	params = TEESMC32_GET_PARAMS(arg32);
+	msec_to_wait = params[0].u.value.a;
+
+	/* set task's state to interruptible sleep */
+	set_current_state(TASK_INTERRUPTIBLE);
+
+	/* take a nap */
+	schedule_timeout(msecs_to_jiffies(msec_to_wait));
+
+	arg32->ret = TEEC_SUCCESS;;
+	return;
+bad:
+	arg32->ret = TEEC_ERROR_BAD_PARAMETERS;
+}
+
 static void handle_rpc_func_cmd_to_supplicant(struct teesmc32_arg *arg32)
 {
 	struct teesmc32_param *params;
@@ -215,11 +240,16 @@ static void handle_rpc_func_cmd(u32 parg32)
 
 	arg32 = tee_shm_pool_p2v(DEV, TZop.Allocator, parg32);
 
-	if (arg32->cmd == TEE_RPC_MUTEX_WAIT)
-		handle_rpc_func_cmd_mutex_wait(arg32);
-	else
+	switch (arg32->cmd) {
+		case TEE_RPC_MUTEX_WAIT:
+			handle_rpc_func_cmd_mutex_wait(arg32);
+			break;
+		case TEE_RPC_WAIT:
+			handle_rpc_func_cmd_wait(arg32);
+			break;
+		default:
 		handle_rpc_func_cmd_to_supplicant(arg32);
-
+	}
 }
 
 static u32 handle_rpc(struct smc_param *param)

--- a/generic/tee_supp_com.h
+++ b/generic/tee_supp_com.h
@@ -33,8 +33,12 @@
 #define TEE_RPC_VALUE		0x00000002
 #define TEE_RPC_LOAD_TA		0x10000001
 #define TEE_RPC_FREE_TA_WITH_FD	0x10000012
-/* Handled within the driver only */
+/*
+ * Handled within the driver only
+ * Keep aligned with optee_os (secure space)
+ */
 #define TEE_RPC_MUTEX_WAIT	0x20000000
+#define TEE_RPC_WAIT		0x30000000
 
 /* Parameters for TEE_RPC_WAIT_MUTEX above */
 #define TEE_MUTEX_WAIT_SLEEP	0


### PR DESCRIPTION
- add new rpc command TEE_RPC_WAIT to enable wait in normal world
- in order to release cpu resource while waiting, invoke scheudle_timeout()
  when TEE_RPC_WAIT is received
