### PR TITLE
tee_shm_allocate(): use size_t for size and check for overflow

### DIFF
--- a/generic/tee_mem.c
+++ b/generic/tee_mem.c
@@ -253,7 +253,7 @@ void tee_shm_pool_destroy(struct device *dev, struct shm_pool *pool)
 	dev_dbg(dev, "> poolH(0x%p)\n", (void *)pool);
 
 #if defined(_DUMP_INFO_ALLOCATOR) && (_DUMP_INFO_ALLOCATOR > 0)
-	tee_shm_pool_dump(dev, allocator, true);
+	tee_shm_pool_dump(dev, pool, true);
 #endif
 
 	tee_shm_pool_reset(dev, pool);
@@ -543,7 +543,7 @@ failed_out:
  *
  */
 void tee_shm_pool_free(struct device *dev, struct shm_pool *pool,
-		unsigned long paddr, uint32_t *size)
+		unsigned long paddr, size_t *size)
 {
 	struct mem_chunk *chunk;
 	struct mem_chunk *tmp;

--- a/generic/tee_mem.h
+++ b/generic/tee_mem.h
@@ -42,7 +42,7 @@ unsigned long tee_shm_pool_alloc(struct device *dev,
 
 
 void tee_shm_pool_free(struct device *dev, struct shm_pool *pool,
-		unsigned long paddr, uint32_t *size);
+		unsigned long paddr, size_t *size);
 
 
 bool tee_shm_pool_incref(struct device *dev, struct shm_pool *pool,

--- a/generic/tee_service.h
+++ b/generic/tee_service.h
@@ -32,7 +32,7 @@ struct tee_session *tee_create_session(const char *devname, bool userApi);
 void tee_delete_session(struct tee_session *ts);
 
 struct tee_shm *tee_shm_allocate(struct tee_targetop *op,
-				 void *vaddr, int size, uint32_t flags);
+				 void *vaddr, size_t size, uint32_t flags);
 void tee_shm_unallocate(struct tee_shm *shm);
 
 TEEC_Result allocate_uuid(struct tee_session *ts);


### PR DESCRIPTION
Fixes failure of xtest 7002 on Foundation_v8 (PLATFORM=vexpress-fvp).

xtest 7002 calls TEEC_AllocateSharedMemory() with a requested size of
0xFFFFFFFE and expects an out-of-memory error. Prior to this commit,
the size after page_size alignment would wrap to 0 and no error would be
returned.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>