### PR TITLE
tz: Fix handling of RPC parameters to supplicant

### DIFF
--- a/core/tee_supp_com.h
+++ b/core/tee_supp_com.h
@@ -28,7 +28,6 @@
 #define TEE_RPC_BUFFER		0x00000001
 #define TEE_RPC_VALUE		0x00000002
 #define TEE_RPC_LOAD_TA		0x10000001
-#define TEE_RPC_FREE_TA_WITH_FD	0x10000012
 /*
  * Handled within the driver only
  * Keep aligned with optee_os (secure space)


### PR DESCRIPTION
Also, drop unused and obsolete TEE_RPC_FREE_TA_WITH_FD.
Tested on HiKey with 64-bit kernel and both 32-bit and 64-bit TEE Core.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>