### PR TITLE
core: tz avoid memory leak and minor fix

### DIFF
--- a/armtz/tee_tz_drv.c
+++ b/armtz/tee_tz_drv.c
@@ -1194,9 +1194,6 @@ static int tz_tee_init(struct platform_device *pdev)
 #endif
 #endif
 
-	tee->shm_flags = TEEC_MEM_INPUT | TEEC_MEM_OUTPUT;
-	tee->test = 0;
-
 	ptee->started = false;
 	ptee->sess_id = 0xAB000000;
 	mutex_init(&ptee->mutex);
@@ -1257,11 +1254,11 @@ static int tz_tee_probe(struct platform_device *pdev)
 
 	ret = tz_tee_init(pdev);
 	if (ret)
-		goto bail1;
+		goto bail0;
 
 	ret = tee_core_add(tee);
 	if (ret)
-		goto bail0;
+		goto bail1;
 
 #ifdef _TEE_DEBUG
 	pr_debug("- tee=%p, id=%d, iminor=%d\n", tee, tee->id,
@@ -1272,6 +1269,7 @@ static int tz_tee_probe(struct platform_device *pdev)
 bail1:
 	tz_tee_deinit(pdev);
 bail0:
+	tee_core_free(tee);
 	return ret;
 }
 

--- a/core/tee_session.c
+++ b/core/tee_session.c
@@ -415,6 +415,7 @@ struct tee_session *tee_session_create_and_open(struct tee_context *ctx,
 	if (!sess) {
 		dev_err(_DEV(tee), "%s: tee_session allocation() failed\n",
 			__func__);
+		tee_put(tee);
 		return ERR_PTR(-ENOMEM);
 	}
 

--- a/include/linux/tee_core.h
+++ b/include/linux/tee_core.h
@@ -184,6 +184,7 @@ int tee_core_del(struct tee *tee);
 
 struct tee *tee_core_alloc(struct device *dev, char *name, int id,
 			   const struct tee_ops *ops, size_t len);
+int tee_core_free(struct tee *tee);
 
 struct tee_ops {
 	struct module *owner;


### PR DESCRIPTION
1. Introduce tee_core_free to make it pair with tee_core_alloc:
   tz_tee_probe may fail, and we need to free resource that requested
   by tee_core_alloc
2. Correct tz_tee_probe failure handle sequence
3. Move shm_flags and test for tee settings to tee_core.c
   "struct tee" settings should not in tz driver, but in core driver.
4. if sess is NULL, should call tee_put(tee)

Signed-off-by: Peng Fan <van.freenix@gmail.com>