### PR TITLE
Support 32-bit client working with 64-bit linux kernel

### DIFF
--- a/core/tee_kernel_api.c
+++ b/core/tee_kernel_api.c
@@ -28,6 +28,7 @@
 
 static void reset_tee_cmd(struct tee_cmd_io *cmd)
 {
+	memset(cmd, 0, sizeof(struct tee_cmd_io));
 	cmd->fd_sess = -1;
 	cmd->cmd = 0;
 	cmd->uuid = NULL;
@@ -230,7 +231,7 @@ TEEC_Result TEEC_AllocateSharedMemory(TEEC_Context *context,
 	shm = (struct tee_shm *)(long)shm_io.fd_shm;
 	shared_memory->buffer = shm->kaddr;
 
-	pr_debug("%s(%zd) => fd=%d, kaddr=%p\n", __func__,
+	pr_debug("%s(%d) => fd=%d, kaddr=%p\n", __func__,
 		 shm_io.size, shm_io.fd_shm, (void *)shared_memory->buffer);
 
 	return TEEC_SUCCESS;

--- a/core/tee_session.c
+++ b/core/tee_session.c
@@ -359,6 +359,9 @@ static int tee_session_release(struct inode *inode, struct file *filp)
 
 const struct file_operations tee_session_fops = {
 	.owner = THIS_MODULE,
+#ifdef CONFIG_COMPAT
+	.compat_ioctl = tee_session_ioctl,
+#endif
 	.unlocked_ioctl = tee_session_ioctl,
 	.release = tee_session_release,
 };
@@ -727,8 +730,7 @@ static void _update_client_tee_cmd(struct tee_session *sess,
 				dev_dbg(_DEV_TEE,
 					"Size has been updated by the TA %zd != %zd\n",
 					size_new,
-					cmd_io->op->params[idx].tmpref.
-					size);
+					cmd_io->op->params[idx].tmpref.size);
 				tee_put_user(ctx, size_new,
 				     &cmd_io->op->params[idx].tmpref.size);
 			}
@@ -741,8 +743,7 @@ static void _update_client_tee_cmd(struct tee_session *sess,
 				dev_err(_DEV_TEE,
 					"  *** Wrong returned size from %d:%zd > %zd\n",
 					idx, size_new,
-					cmd_io->op->params[idx].tmpref.
-					size);
+					cmd_io->op->params[idx].tmpref.size);
 
 			else if (tee_copy_to_user
 				 (ctx,

--- a/core/tee_shm.c
+++ b/core/tee_shm.c
@@ -397,8 +397,6 @@ int tee_shm_alloc_io(struct tee_context *ctx, struct tee_shm_io *shm_io)
 
 	if (ctx->usr_client)
 		shm_io->fd_shm = 0;
-	else
-		shm_io->ptr = NULL;
 
 	shm = tee_shm_alloc(tee, shm_io->size, shm_io->flags);
 	if (IS_ERR_OR_NULL(shm)) {
@@ -416,8 +414,7 @@ int tee_shm_alloc_io(struct tee_context *ctx, struct tee_shm_io *shm_io)
 		}
 
 		shm->flags |= TEEC_MEM_DMABUF;
-	} else
-		shm_io->ptr = shm;
+	}
 
 	shm->ctx = ctx;
 	shm->dev = get_device(_DEV(tee));

--- a/core/tee_supp_com.h
+++ b/core/tee_supp_com.h
@@ -65,16 +65,21 @@ struct tee_rpc_free {
 };
 
 struct tee_rpc_cmd {
-	void *buffer;
+	union {
+		void    *buffer;
+		uint64_t padding_buf;
+	};
 	uint32_t size;
 	uint32_t type;
 	int fd;
+	int reserved;
 };
 
 struct tee_rpc_invoke {
 	uint32_t cmd;
 	uint32_t res;
 	uint32_t nbr_bf;
+	uint32_t reserved;
 	struct tee_rpc_cmd cmds[TEE_RPC_BUFFER_NUMBER];
 };
 

--- a/include/linux/tee_client_api.h
+++ b/include/linux/tee_client_api.h
@@ -270,6 +270,14 @@ typedef struct {
 } TEEC_UUID;
 
 /**
+ * In terms of compatible kernel, the data struct shared by client application
+ * and TEE driver should be restructrued in "compatible" rules. To keep GP's
+ * standard in compatibility mode, the anonymous padding members are filled
+ * in the struct definition below.
+ */
+
+
+/**
  * struct TEEC_SharedMemory - Memory to transfer data between a client
  * application and trusted code.
  *
@@ -286,18 +294,26 @@ typedef struct {
  * is responsible to populate the buffer pointer.
  */
 typedef struct {
-	void *buffer;
-	size_t size;
+	union {
+		void *buffer;
+		uint64_t padding_ptr;
+	};
+	union {
+		size_t size;
+		uint64_t padding_sz;
+	};
 	uint32_t flags;
 	/*
 	 * identifier can store a handle (int) or a structure pointer (void *).
 	 * define this union to match case where sizeof(int)!=sizeof(void *).
 	 */
+	uint32_t reserved;
 	union {
 		int fd;
 		void *ptr;
+		uint64_t padding_d;
 	} d;
-	uint8_t registered;
+	uint64_t registered;
 } TEEC_SharedMemory;
 
 /**
@@ -313,8 +329,14 @@ typedef struct {
  * operation to be called.
  */
 typedef struct {
-	void *buffer;
-	size_t size;
+	union {
+		void *buffer;
+		uint64_t padding_ptr;
+	};
+	union {
+		size_t size;
+		uint64_t padding_sz;
+	};
 } TEEC_TempMemoryReference;
 
 /**
@@ -333,9 +355,18 @@ typedef struct {
  *
  */
 typedef struct {
-	TEEC_SharedMemory *parent;
-	size_t size;
-	size_t offset;
+	union {
+		TEEC_SharedMemory *parent;
+		uint64_t padding_ptr;
+	};
+	union {
+		size_t size;
+		uint64_t padding_sz;
+	};
+	union {
+		size_t offset;
+		uint64_t padding_off;
+	};
 } TEEC_RegisteredMemoryReference;
 
 /**
@@ -400,9 +431,12 @@ typedef struct {
 	uint32_t paramTypes;
 	TEEC_Parameter params[TEEC_CONFIG_PAYLOAD_REF_COUNT];
 	/* Implementation-Defined */
-	TEEC_Session *session;
+	union {
+		TEEC_Session *session;
+		uint64_t padding_ptr;
+	};
 	TEEC_SharedMemory memRefs[TEEC_CONFIG_PAYLOAD_REF_COUNT];
-	uint32_t flags;
+	uint64_t flags;
 } TEEC_Operation;
 
 /**

--- a/include/linux/tee_ioc.h
+++ b/include/linux/tee_ioc.h
@@ -36,22 +36,42 @@ struct tee_cmd_io {
 	TEEC_Result err;
 	uint32_t origin;
 	uint32_t cmd;
-	TEEC_UUID __user *uuid;
-	void __user *data;
-	uint32_t data_size;
-	TEEC_Operation __user *op;
 	int fd_sess;
+	/*
+	 * Here fd_sess is 32-bit variable. Since TEEC_Result also is defined as
+	 * "uint32_t", this structure is aligned.
+	 */
+	union {
+		TEEC_UUID __user *uuid;
+		uint64_t padding_uuid;
+	};
+	union {
+		void __user *data;
+		uint64_t padding_data;
+	};
+	union {
+		TEEC_Operation __user *op;
+		uint64_t padding_op;
+	};
+	uint32_t data_size;
+	int32_t reserved;
 };
 
 struct tee_shm_io {
-	void __user *buffer;
-	size_t size;
-	uint32_t flags;
 	union {
-		int fd_shm;
-		void *ptr;
+		void __user *buffer;
+		uint64_t padding_buf;
 	};
-	uint8_t registered;
+	uint32_t size;
+	uint32_t flags;
+	/*
+	 * Here fd_shm is 32-bit. To be compliant with the convention of file
+	 * descriptor definition, fd_shm is defined as "int" type other
+	 * than "int32_t". Even though using "int32_t" is more obvious to
+	 * indicate that we intend to keep this structure aligned.
+	 */
+	int fd_shm;
+	uint32_t registered;
 };
 
 #define TEE_OPEN_SESSION_IOC		_IOWR('t', 161, struct tee_cmd_io)


### PR DESCRIPTION
Since compat ioctl is not supported by current driver, 32-bit client
application will fail to call ioctl if linux kernel is 64-bit.

Meanwhile, client and driver are sharing lots of data struct which is
unaligned in 64-bit kernel and those struct is widely used by *sizeof*
operator both in client and driver.
If client is 32-bit, the data size may be totally different in 64-bit
kernel and data copy between client and driver will be failed.

This commit includes
- add compat ioctl
- restructure unaligned struct and add padding member

Signed-off-by: Aijun Sun <aijun.sun@linaro.org>