### PR TITLE
Enable compilation of driver in THUMB mode.

### DIFF
--- a/armtz/tee_smc-arm.S
+++ b/armtz/tee_smc-arm.S
@@ -14,7 +14,11 @@
 
 .text
 .balign 4
-.code 32
+#ifdef CONFIG_ARM_THUMB
+.thumb
+#else
+.arm
+#endif
 
 	/* void tee_smc_call(struct smc_param *param); */
 	.globl	tee_smc_call


### PR DESCRIPTION
Make tee_smc-arm.S file compilation configurable to compile
in either ARM or THUMB mode depending on CONFIG_ARM_THUMB
macro defined in linux kernel. Previously it could be compiled
only in ARM mode.

Kindly refer to https://sourceware.org/binutils/docs/as/ARM-Directives.html 
for more information.

Signed-off-by: Sumit Garg <sumit.garg@nxp.com>