### PR TITLE
Fix invalid usage of platform_driver in debug builds

### DIFF
--- a/armtz/tee_tz_drv.c
+++ b/armtz/tee_tz_drv.c
@@ -1221,7 +1221,7 @@ static int tz_tee_probe(struct platform_device *pdev)
 		pdev->name, pdev->id, dev_name(dev));
 #ifdef _TEE_DEBUG
 	pr_debug("- dev=%p\n", dev);
-	pr_debug("- dev->parent=%p\n", dev->ctx);
+	pr_debug("- dev->parent=%p\n", dev->parent);
 	pr_debug("- dev->driver=%p\n", dev->driver);
 #endif
 


### PR DESCRIPTION
Signed-off-by: Zoltan Kuscsik <zoltan.kuscsik@linaro.org>