### PR TITLE
Allow the driver to be linked into the kernel image

### DIFF
--- a/armtz/tee_tz_drv.c
+++ b/armtz/tee_tz_drv.c
@@ -1143,7 +1143,7 @@ static int tz_stop(struct tee *tee)
 
 /******************************************************************************/
 
-const struct tee_ops tee_fops = {
+static const struct tee_ops tee_fops = {
 	.type = "tz",
 	.owner = THIS_MODULE,
 	.start = tz_start,

--- a/core/tee_core.c
+++ b/core/tee_core.c
@@ -406,7 +406,7 @@ static long tee_ioctl(struct file *filp, unsigned int cmd, unsigned long arg)
 	return ret;
 }
 
-const struct file_operations tee_fops = {
+static const struct file_operations tee_fops = {
 	.owner = THIS_MODULE,
 	.read = tee_supp_read,
 	.write = tee_supp_write,


### PR DESCRIPTION
With the minimal Kbuild infrastructure to bring the OPTEE
linuxdriver in kernel tree, the following build error occurs
when configuring the driver as builtin into the kernel:

```
<path-to>/armtz/built-in.o:(.rodata+0x50):
  multiple definition of `tee_fops'
<path-to>/core/built-in.o:(.rodata+0x60):
  first defined here
```

This is due to name clash and is not reproduced when OPTEE is built as
loadable modules. Fix it by declaring the fops structures as static.

Signed-off-by: Eugeniu Rosca <erosca@de.adit-jv.com>